### PR TITLE
2022_09_11_request

### DIFF
--- a/src/main/java/com/csStudy/CardGame/configuration/WebConfiguration.java
+++ b/src/main/java/com/csStudy/CardGame/configuration/WebConfiguration.java
@@ -1,8 +1,12 @@
 package com.csStudy.CardGame.configuration;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebConfiguration implements WebMvcConfigurer {
@@ -12,5 +16,10 @@ public class WebConfiguration implements WebMvcConfigurer {
                 .allowedOrigins("*")
                 .allowedMethods("GET", "POST");
 
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add( new PageableHandlerMethodArgumentResolver());
     }
 }

--- a/src/main/java/com/csStudy/CardGame/domain/card/controller/CardController.java
+++ b/src/main/java/com/csStudy/CardGame/domain/card/controller/CardController.java
@@ -1,12 +1,17 @@
 package com.csStudy.CardGame.domain.card.controller;
 
 import com.csStudy.CardGame.domain.card.dto.CardDto;
-import com.csStudy.CardGame.domain.card.dto.CardForm;
+import com.csStudy.CardGame.domain.card.dto.NewCardForm;
 import com.csStudy.CardGame.domain.card.service.CardService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
 
 /* 카드 관련 API */
 @RestController
@@ -22,9 +27,14 @@ public class CardController {
     // 카드 추가
     @PostMapping("/cards")
     @PreAuthorize("hasRole('ROLE_USER')")
-    public ResponseEntity<?> addCard(@RequestBody CardForm cardForm){
-        CardDto addedCard = cardService.addCard(cardForm);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Void> addCard(@RequestBody NewCardForm newCardForm){
+        CardDto addedCard = cardService.addCard(newCardForm);
+        URI location = ServletUriComponentsBuilder
+                .fromUriString("/cards")
+                .path("/{id}")
+                .buildAndExpand(addedCard.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(null);
     }
 
     // 카드 수정
@@ -41,4 +51,14 @@ public class CardController {
         cardService.deleteCard(id);
     }
 
+    // 카드 조회
+    @GetMapping("/cards")
+    public ResponseEntity<List<CardDto>> getCards(
+            @RequestParam Long cid,
+            Pageable pageable
+    ) {
+        return ResponseEntity
+                .ok()
+                .body(cardService.findCardsByCategory(cid, pageable));
+    }
 }

--- a/src/main/java/com/csStudy/CardGame/domain/card/dto/NewCardForm.java
+++ b/src/main/java/com/csStudy/CardGame/domain/card/dto/NewCardForm.java
@@ -7,7 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CardForm {
+public class NewCardForm {
 
     private String question;
 

--- a/src/main/java/com/csStudy/CardGame/domain/card/entity/Card.java
+++ b/src/main/java/com/csStudy/CardGame/domain/card/entity/Card.java
@@ -2,11 +2,9 @@ package com.csStudy.CardGame.domain.card.entity;
 
 
 import com.csStudy.CardGame.domain.category.entity.Category;
-import com.csStudy.CardGame.domain.member.entity.Member;
 import lombok.*;
 
 import javax.persistence.*;
-import java.util.Objects;
 
 @Entity
 @Cacheable
@@ -24,12 +22,6 @@ public class Card {
 
     @Column(name = "answer", nullable = false, columnDefinition = "TEXT")
     private String answer;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(
-            name = "owner_id"
-    )
-    private Member owner;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
@@ -54,12 +46,6 @@ public class Card {
     }
 
     public void changeCategory(Category category) {
-        // 기존 카테고리와의 관계 해제
-        if (this.category != null)
-            this.category.removeCard(this);
-
-        // 새 카테고리 설정
-        category.addCard(this);
         this.category = category;
     }
 

--- a/src/main/java/com/csStudy/CardGame/domain/card/mapper/CardMapper.java
+++ b/src/main/java/com/csStudy/CardGame/domain/card/mapper/CardMapper.java
@@ -1,12 +1,12 @@
 package com.csStudy.CardGame.domain.card.mapper;
 
-import com.csStudy.CardGame.domain.card.dto.CardForm;
+import com.csStudy.CardGame.domain.card.dto.NewCardForm;
 import com.csStudy.CardGame.domain.card.entity.Card;
 import com.csStudy.CardGame.domain.card.dto.CardDto;
 
 
 public interface CardMapper {
-    Card toEntity(CardForm cardForm);
+    Card toEntity(NewCardForm newCardForm);
 
     CardDto toDetailCard(Card card);
 

--- a/src/main/java/com/csStudy/CardGame/domain/card/mapper/CardMapperImpl.java
+++ b/src/main/java/com/csStudy/CardGame/domain/card/mapper/CardMapperImpl.java
@@ -1,6 +1,6 @@
 package com.csStudy.CardGame.domain.card.mapper;
 
-import com.csStudy.CardGame.domain.card.dto.CardForm;
+import com.csStudy.CardGame.domain.card.dto.NewCardForm;
 import com.csStudy.CardGame.domain.card.entity.Card;
 import com.csStudy.CardGame.domain.card.dto.CardDto;
 import org.springframework.stereotype.Component;
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 public class CardMapperImpl implements CardMapper{
 
     @Override
-    public Card toEntity(CardForm cardForm) {
+    public Card toEntity(NewCardForm newCardForm) {
         return Card.builder()
-                .question(cardForm.getQuestion())
-                .answer(cardForm.getAnswer())
+                .question(newCardForm.getQuestion())
+                .answer(newCardForm.getAnswer())
                 .build();
     }
 

--- a/src/main/java/com/csStudy/CardGame/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/csStudy/CardGame/domain/card/repository/CardRepository.java
@@ -1,20 +1,17 @@
 package com.csStudy.CardGame.domain.card.repository;
 
 import com.csStudy.CardGame.domain.card.entity.Card;
-import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Collection;
 import java.util.List;
 
 
 public interface CardRepository extends JpaRepository<Card, Long> {
 
     // 특정 category 에 해당하는 카드 리스트 검색
-    List<Card> findByCategory_Id(Long cid);
-
-    // 특정 category 리스트중 하나에 해당하는 카드 리스트 검색
-    List<Card> findByCategory_IdIn(Collection<Long> cidList);
+    Page<Card> findByCategory_IdOrderByIdAsc(Long categoryId, Pageable pageable);
 
     // 질문이 특정 keyword 를 포함하는 카드 리스트 검색
     List<Card> findByQuestionContaining(String keyword);

--- a/src/main/java/com/csStudy/CardGame/domain/card/service/CardService.java
+++ b/src/main/java/com/csStudy/CardGame/domain/card/service/CardService.java
@@ -1,9 +1,9 @@
 package com.csStudy.CardGame.domain.card.service;
 
 import com.csStudy.CardGame.domain.card.dto.CardDto;
-import com.csStudy.CardGame.domain.card.dto.CardForm;
+import com.csStudy.CardGame.domain.card.dto.NewCardForm;
+import org.springframework.data.domain.Pageable;
 
-import java.util.Collection;
 import java.util.List;
 
 public interface CardService {
@@ -14,14 +14,14 @@ public interface CardService {
     // id로 카드 조회
     CardDto findCardById(Long id);
 
-    // 특정 카테고리들에 속하는 카드
-    List<CardDto> findCardsByCategories(Collection<Long> categoryIdList);
+    // 특정 카테고리에 속하는 카드
+    List<CardDto> findCardsByCategory(Long categoryId, Pageable pageable);
 
     // 질문에 특정 키워드를 포함하는 카드
     List<CardDto> findCardsByQuestion(String keyword);
 
     // 새로운 카드를 추가
-    CardDto addCard(CardForm cardForm);
+    CardDto addCard(NewCardForm newCardForm);
 
     // 카드 정보를 수정
     void editCard(CardDto cardDto);

--- a/src/main/java/com/csStudy/CardGame/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/csStudy/CardGame/domain/category/controller/CategoryController.java
@@ -1,8 +1,8 @@
 package com.csStudy.CardGame.domain.category.controller;
 
-import com.csStudy.CardGame.domain.category.dto.NewCategory;
-import com.csStudy.CardGame.domain.category.dto.SimpleCategory;
-import com.csStudy.CardGame.domain.category.dto.DetailCategory;
+import com.csStudy.CardGame.domain.category.dto.NewCategoryForm;
+import com.csStudy.CardGame.domain.category.dto.CategoryDto;
+import com.csStudy.CardGame.domain.category.dto.CategoryDtoWithOwnerInfo;
 import com.csStudy.CardGame.domain.category.service.CategoryService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,7 +34,7 @@ public class CategoryController {
 
     // 전체 카테고리 또는 선택된 카테고리 리스트를 반환하는 API
     @GetMapping("/categories")
-    public ResponseEntity<List<SimpleCategory>> getCategories(@RequestParam(required = false) List<Long> selected) {
+    public ResponseEntity<List<CategoryDto>> getCategories(@RequestParam(required = false) List<Long> selected) {
         if (selected == null) {
             return new ResponseEntity<>(categoryService.getAllCategories(), HttpStatus.OK);
         }
@@ -45,13 +45,13 @@ public class CategoryController {
 
     // 특정 카테고리를 반환하는 API
     @GetMapping("/categories/{cid}")
-    public SimpleCategory getCategory(@PathVariable Long cid) {
+    public CategoryDto getCategory(@PathVariable Long cid) {
         return categoryService.getCategoryById(cid);
     }
 
     // 전체 카테고리 또는 선택된 카테고리 상세조회 리스트를 반환하는 API
     @GetMapping("/categories/detail")
-    public List<DetailCategory> getCategoriesDetail(@RequestParam List<Long> selected) {
+    public List<CategoryDtoWithOwnerInfo> getCategoriesDetail(@RequestParam List<Long> selected) {
         if (selected == null) {
             return categoryService.getAllCategoriesDetail();
         }
@@ -62,7 +62,7 @@ public class CategoryController {
 
     // 특정 카테고리 상세 조회 API
     @GetMapping("/categories/detail/{cid}")
-    public DetailCategory getCategoryDetail(@PathVariable Long cid) {
+    public CategoryDtoWithOwnerInfo getCategoryDetail(@PathVariable Long cid) {
         return categoryService.getCategoryDetailById(cid);
     }
 
@@ -74,18 +74,18 @@ public class CategoryController {
         ObjectMapper mapper = new ObjectMapper();
 
         // 추가
-        List<NewCategory> insertedCategoryList = new ArrayList<>();
+        List<NewCategoryForm> insertedCategoryList = new ArrayList<>();
         JSONArray insertList = jObject.getJSONArray("insert");
         for (Object o: insertList) {
-            NewCategory newCategory = mapper.readValue(o.toString(), NewCategory.class);
-            insertedCategoryList.add(newCategory);
+            NewCategoryForm newCategoryForm = mapper.readValue(o.toString(), NewCategoryForm.class);
+            insertedCategoryList.add(newCategoryForm);
         }
 
         // 수정
-        List<SimpleCategory> updatedCategoryList = new ArrayList<>();
+        List<CategoryDto> updatedCategoryList = new ArrayList<>();
         JSONArray updateList = jObject.getJSONArray("update");
         for (Object o: updateList) {
-            SimpleCategory dto = mapper.readValue(o.toString(), SimpleCategory.class);
+            CategoryDto dto = mapper.readValue(o.toString(), CategoryDto.class);
             updatedCategoryList.add(dto);
         }
 
@@ -93,7 +93,7 @@ public class CategoryController {
         Set<Long> deletedCategorySet = new HashSet<>();
         JSONArray deleteList = jObject.getJSONArray("delete");
         for (Object o: deleteList) {
-            SimpleCategory dto = mapper.readValue(o.toString(), SimpleCategory.class);
+            CategoryDto dto = mapper.readValue(o.toString(), CategoryDto.class);
             deletedCategorySet.add(dto.getId());
         }
 

--- a/src/main/java/com/csStudy/CardGame/domain/category/dto/CategoryDto.java
+++ b/src/main/java/com/csStudy/CardGame/domain/category/dto/CategoryDto.java
@@ -4,10 +4,14 @@ import lombok.*;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class NewCategory {
+public class CategoryDto {
+
+    private Long id;
+
     private String name;
+
     private int cardCount;
 }

--- a/src/main/java/com/csStudy/CardGame/domain/category/dto/CategoryDtoWithOwnerInfo.java
+++ b/src/main/java/com/csStudy/CardGame/domain/category/dto/CategoryDtoWithOwnerInfo.java
@@ -1,23 +1,22 @@
 package com.csStudy.CardGame.domain.category.dto;
 
-import com.csStudy.CardGame.domain.card.dto.CardDto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
+import java.util.UUID;
 
 @Builder
 @Getter
-public class DetailCategory {
+public class CategoryDtoWithOwnerInfo {
     private Long id;
 
     private String name;
 
     private int cardCount;
 
-    private Long ownerId;
+    private UUID ownerId;
 
-    private String ownerName;
+    private String ownerNickname;
 
-    private List<CardDto> cards;
+    private String ownerEmail;
 }

--- a/src/main/java/com/csStudy/CardGame/domain/category/dto/NewCategoryForm.java
+++ b/src/main/java/com/csStudy/CardGame/domain/category/dto/NewCategoryForm.java
@@ -4,14 +4,10 @@ import lombok.*;
 
 @Getter
 @Setter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SimpleCategory {
-
-    private Long id;
-
+@Builder
+public class NewCategoryForm {
     private String name;
-
     private int cardCount;
 }

--- a/src/main/java/com/csStudy/CardGame/domain/category/entity/Category.java
+++ b/src/main/java/com/csStudy/CardGame/domain/category/entity/Category.java
@@ -39,25 +39,11 @@ public class Category {
     )
     private Member owner;
 
-    // TODO: 2022-09-10 OneToMany 매핑시 paging 이슈에 대해 알아보기
-    @OneToMany(mappedBy = "category")
-    @Builder.Default
-    @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-    private List<Card> cards = new ArrayList<>();
-
     public void changeName(String name) {
         this.name = name;
     }
 
     public void changeOwner(Member owner) {
         this.owner = owner;
-    }
-
-    public void addCard(Card card) {
-        this.cards.add(card);
-    }
-
-    public void removeCard(Card card) {
-        this.cards.remove(card);
     }
 }

--- a/src/main/java/com/csStudy/CardGame/domain/category/mapper/CategoryMapper.java
+++ b/src/main/java/com/csStudy/CardGame/domain/category/mapper/CategoryMapper.java
@@ -1,11 +1,14 @@
 package com.csStudy.CardGame.domain.category.mapper;
 
-import com.csStudy.CardGame.domain.category.dto.NewCategory;
+import com.csStudy.CardGame.domain.category.dto.CategoryDtoWithOwnerInfo;
+import com.csStudy.CardGame.domain.category.dto.NewCategoryForm;
 import com.csStudy.CardGame.domain.category.entity.Category;
-import com.csStudy.CardGame.domain.category.dto.SimpleCategory;
+import com.csStudy.CardGame.domain.category.dto.CategoryDto;
 
 public interface CategoryMapper {
-    Category toEntity(NewCategory newCategory);
+    Category toEntity(NewCategoryForm newCategoryForm);
 
-    SimpleCategory toSimpleCategory(Category category);
+    CategoryDto toCategoryDto(Category category);
+
+    CategoryDtoWithOwnerInfo toCategoryDtoWithOwnerInfo(Category category);
 }

--- a/src/main/java/com/csStudy/CardGame/domain/category/mapper/CategoryMapperImpl.java
+++ b/src/main/java/com/csStudy/CardGame/domain/category/mapper/CategoryMapperImpl.java
@@ -1,33 +1,46 @@
 package com.csStudy.CardGame.domain.category.mapper;
 
-import com.csStudy.CardGame.domain.category.dto.NewCategory;
+import com.csStudy.CardGame.domain.category.dto.CategoryDtoWithOwnerInfo;
+import com.csStudy.CardGame.domain.category.dto.NewCategoryForm;
 import com.csStudy.CardGame.domain.category.entity.Category;
-import com.csStudy.CardGame.domain.category.dto.SimpleCategory;
+import com.csStudy.CardGame.domain.category.dto.CategoryDto;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CategoryMapperImpl implements CategoryMapper{
 
     @Override
-    public Category toEntity(NewCategory newCategory) {
+    public Category toEntity(NewCategoryForm newCategoryForm) {
         return Category.builder()
-                .name(newCategory.getName())
-                .cardCount(newCategory.getCardCount())
+                .name(newCategoryForm.getName())
+                .cardCount(newCategoryForm.getCardCount())
                 .build();
     }
 
     @Override
-    public SimpleCategory toSimpleCategory(Category category) {
+    public CategoryDto toCategoryDto(Category category) {
         if (category == null) {
             return null;
         }
         else {
-            return SimpleCategory.builder()
+            return CategoryDto.builder()
                     .id(category.getId())
                     .name(category.getName())
                     .cardCount(category.getCardCount())
                     .build();
         }
+    }
+
+    @Override
+    public CategoryDtoWithOwnerInfo toCategoryDtoWithOwnerInfo(Category category) {
+        return CategoryDtoWithOwnerInfo.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .cardCount(category.getCardCount())
+                .ownerId(category.getOwner().getId())
+                .ownerNickname(category.getOwner().getNickname())
+                .ownerEmail(category.getOwner().getEmail())
+                .build();
     }
 
 }

--- a/src/main/java/com/csStudy/CardGame/domain/category/service/CategoryService.java
+++ b/src/main/java/com/csStudy/CardGame/domain/category/service/CategoryService.java
@@ -1,8 +1,8 @@
 package com.csStudy.CardGame.domain.category.service;
 
-import com.csStudy.CardGame.domain.category.dto.DetailCategory;
-import com.csStudy.CardGame.domain.category.dto.NewCategory;
-import com.csStudy.CardGame.domain.category.dto.SimpleCategory;
+import com.csStudy.CardGame.domain.category.dto.CategoryDtoWithOwnerInfo;
+import com.csStudy.CardGame.domain.category.dto.NewCategoryForm;
+import com.csStudy.CardGame.domain.category.dto.CategoryDto;
 
 import java.util.Collection;
 import java.util.List;
@@ -11,23 +11,23 @@ import java.util.Set;
 public interface CategoryService {
     /* 조회 */
     // 모든 카테고리 조회
-    List<SimpleCategory> getAllCategories();
+    List<CategoryDto> getAllCategories();
 
     // 모든 카테고리 상세 조회
-    List<DetailCategory> getAllCategoriesDetail();
+    List<CategoryDtoWithOwnerInfo> getAllCategoriesDetail();
 
     // 선택된 카테고리 조회
-    List<SimpleCategory> getSelectedCategories(Collection<Long> categoryIdSet);
+    List<CategoryDto> getSelectedCategories(Collection<Long> categoryIdSet);
 
     // 선택된 카테고리 상세 조회
-    List<DetailCategory> getSelectedCategoriesDetail(Collection<Long> categoryIdSet);
+    List<CategoryDtoWithOwnerInfo> getSelectedCategoriesDetail(Collection<Long> categoryIdSet);
 
     // 특정 카테고리 조회
-    SimpleCategory getCategoryById(Long id);
+    CategoryDto getCategoryById(Long id);
 
     // 특정 카테고리 상세조회
-    DetailCategory getCategoryDetailById(Long id);
+    CategoryDtoWithOwnerInfo getCategoryDetailById(Long id);
 
     // 카테고리 변경사항(추가, 수정, 삭제) 반영
-    boolean changeCategories(List<NewCategory> insertedList, List<SimpleCategory> updatedList, Set<Long> deletedList);
+    boolean changeCategories(List<NewCategoryForm> insertedList, List<CategoryDto> updatedList, Set<Long> deletedList);
 }

--- a/src/main/java/com/csStudy/CardGame/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/csStudy/CardGame/domain/member/service/MemberServiceImpl.java
@@ -56,6 +56,7 @@ public class MemberServiceImpl implements MemberService {
         return memberMapper.toDto(memberRepository.findById(memberId).orElseThrow(() -> ApiErrorException.createException(
                 ApiErrorEnums.RESOURCE_NOT_FOUND,
                 HttpStatus.NOT_FOUND,
+                null,
                 null
         )));
     }

--- a/src/main/java/com/csStudy/CardGame/exception/ApiErrorEnums.java
+++ b/src/main/java/com/csStudy/CardGame/exception/ApiErrorEnums.java
@@ -14,6 +14,7 @@ public enum ApiErrorEnums implements ApiError{
     INVALID_EMAIL_OR_PASSWORD(4005, "INVALID_EMAIL_OR_PASSWORD", "등록되지 않은 이메일 또는 잘못된 패스워드입니다."),
     EXPIRED_TOKEN(4006, "EXPIRED_TOKEN", "만료된 토큰입니다."),
     INVALID_TOKEN(4007, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    INVALID_ACCESS(4008, "INVALID_ACCESS", "잘못된 접근입니다."),
     INTERNAL_SERVER_ERROR(5000,"INTERNAL_SERVER_ERROR","서버 에러입니다.");
 
     private final int errorCode;

--- a/src/main/java/com/csStudy/CardGame/exception/ApiErrorException.java
+++ b/src/main/java/com/csStudy/CardGame/exception/ApiErrorException.java
@@ -10,22 +10,24 @@ import org.springframework.http.HttpStatus;
 @Setter
 public class ApiErrorException extends RuntimeException {
     private HttpStatus status;
-    private String     errorName   ;
-    private int        errorCode   ;
-    private String     errorMessage;
+    private String errorName;
+    private int errorCode;
+    private String errorMessage;
+    private String errorReason;
 
     // constructors
-    public ApiErrorException(ApiError error, HttpStatus status){
+    private ApiErrorException(ApiError error, HttpStatus status, String errorReason){
         this.status = status;
         this.errorCode = error.getErrorCode();
         this.errorName = error.getErrorName();
         this.errorMessage = error.getErrorMessage();
+        this.errorReason = errorReason;
     }
 
     // raise utility functions
-    public static ApiErrorException createException(ApiError error, HttpStatus status, String logMessage) {
+    public static ApiErrorException createException(ApiError errorType, HttpStatus httpStatus, String errorReason, String logMessage) {
         if (logMessage != null)
             log.info(logMessage);
-        return new ApiErrorException(error, status);
+        return new ApiErrorException(errorType, httpStatus, errorReason);
     }
 }


### PR DESCRIPTION
* fix: jwtTokenProvider 에서 SecurityConfiguration 에서 등록된 AuthenticationManager 를 주입받는 것으로 인해 DI 사이클이 발생하는 문제 수정
* fix: Card 엔티티에 잘못 추가된 Owner 와의 관계 매핑 제거
* feat: ApiErrorEnums 종류 추가
* feat: ApiErrorException 에 발생 이유를 구체적으로 설명해야할 경우 사용할 reason 필드 추가
* feat: 특정 Category 에 속한 Card 리스트를 조회하는 API 추가 및 pagination 적용
* refactor: Category 엔티티에서 불필요한 OneToMany 매핑(Cards) 제거
* refactor: 누락된 예외 케이스 처리